### PR TITLE
Hotfix/#114 ready health recovery refetch

### DIFF
--- a/src/app/providers/useReadyHealthMonitor.ts
+++ b/src/app/providers/useReadyHealthMonitor.ts
@@ -3,26 +3,79 @@ import {
   fetchReadyHealth,
   isReadyForRemoteSync,
 } from '@entities/visit';
+import { useQueryClient, type QueryClient } from '@tanstack/react-query';
+import {
+  REMOTE_SYNC_AVAILABILITY,
+  setRemoteSyncAvailability,
+} from '@shared/lib';
 import { useEffect } from 'react';
 
 const READY_HEALTH_POLL_INTERVAL_MS = 60_000;
+const REMOTE_SYNC_QUERY_KEYS = [
+  ['purposeList'],
+  ['residenceList'],
+  ['publicResidenceList'],
+] as const;
+
+const cancelRemoteSyncQueries = async (
+  queryClient: QueryClient
+): Promise<void> => {
+  await Promise.all(
+    REMOTE_SYNC_QUERY_KEYS.map((queryKey) =>
+      queryClient.cancelQueries({ queryKey })
+    )
+  );
+};
+
+const invalidateRemoteSyncQueries = async (
+  queryClient: QueryClient
+): Promise<void> => {
+  await Promise.all(
+    REMOTE_SYNC_QUERY_KEYS.map((queryKey) =>
+      queryClient.invalidateQueries({ queryKey })
+    )
+  );
+};
 
 export const useReadyHealthMonitor = (): void => {
+  const queryClient = useQueryClient();
+
   useEffect(() => {
     let requestInFlight = false;
     let disposed = false;
+    let wasReadyForRemoteSync = false;
+
+    const applyReadyState = async (readyForRemoteSync: boolean) => {
+      if (disposed) return;
+
+      if (!readyForRemoteSync) {
+        wasReadyForRemoteSync = false;
+        setRemoteSyncAvailability(REMOTE_SYNC_AVAILABILITY.UNREADY);
+        await cancelRemoteSyncQueries(queryClient);
+        return;
+      }
+
+      const recovered = !wasReadyForRemoteSync;
+      wasReadyForRemoteSync = true;
+      setRemoteSyncAvailability(REMOTE_SYNC_AVAILABILITY.READY);
+
+      if (recovered) {
+        await invalidateRemoteSyncQueries(queryClient);
+      }
+
+      await drainCheckInQueue().catch(() => undefined);
+    };
 
     const checkReadiness = async (): Promise<void> => {
       if (requestInFlight || disposed) return;
       requestInFlight = true;
 
-      const health = await fetchReadyHealth().catch(() => null);
-
-      if (health && !disposed && isReadyForRemoteSync(health)) {
-        await drainCheckInQueue().catch(() => undefined);
+      try {
+        const health = await fetchReadyHealth().catch(() => null);
+        await applyReadyState(health !== null && isReadyForRemoteSync(health));
+      } finally {
+        requestInFlight = false;
       }
-
-      requestInFlight = false;
     };
 
     void checkReadiness();
@@ -38,5 +91,5 @@ export const useReadyHealthMonitor = (): void => {
       window.clearInterval(intervalId);
       window.removeEventListener('online', checkOnOnline);
     };
-  }, []);
+  }, [queryClient]);
 };

--- a/src/app/providers/useReadyHealthMonitor.ts
+++ b/src/app/providers/useReadyHealthMonitor.ts
@@ -11,6 +11,7 @@ import {
 import { useEffect } from 'react';
 
 const READY_HEALTH_POLL_INTERVAL_MS = 60_000;
+const READY_HEALTH_RECOVERY_POLL_INTERVAL_MS = 5_000;
 const REMOTE_SYNC_QUERY_KEYS = [
   ['purposeList'],
   ['residenceList'],
@@ -44,12 +45,33 @@ export const useReadyHealthMonitor = (): void => {
     let requestInFlight = false;
     let disposed = false;
     let wasReadyForRemoteSync = false;
+    let pollIntervalMs = READY_HEALTH_POLL_INTERVAL_MS;
+    let timeoutId: number | null = null;
+
+    const clearScheduledCheck = () => {
+      if (timeoutId === null) return;
+
+      window.clearTimeout(timeoutId);
+      timeoutId = null;
+    };
+
+    const scheduleNextCheck = () => {
+      clearScheduledCheck();
+
+      if (disposed) return;
+
+      timeoutId = window.setTimeout(
+        () => void checkReadiness(),
+        pollIntervalMs
+      );
+    };
 
     const applyReadyState = async (readyForRemoteSync: boolean) => {
       if (disposed) return;
 
       if (!readyForRemoteSync) {
         wasReadyForRemoteSync = false;
+        pollIntervalMs = READY_HEALTH_RECOVERY_POLL_INTERVAL_MS;
         setRemoteSyncAvailability(REMOTE_SYNC_AVAILABILITY.UNREADY);
         await cancelRemoteSyncQueries(queryClient);
         return;
@@ -57,6 +79,7 @@ export const useReadyHealthMonitor = (): void => {
 
       const recovered = !wasReadyForRemoteSync;
       wasReadyForRemoteSync = true;
+      pollIntervalMs = READY_HEALTH_POLL_INTERVAL_MS;
       setRemoteSyncAvailability(REMOTE_SYNC_AVAILABILITY.READY);
 
       if (recovered) {
@@ -68,6 +91,7 @@ export const useReadyHealthMonitor = (): void => {
 
     const checkReadiness = async (): Promise<void> => {
       if (requestInFlight || disposed) return;
+      clearScheduledCheck();
       requestInFlight = true;
 
       try {
@@ -75,20 +99,17 @@ export const useReadyHealthMonitor = (): void => {
         await applyReadyState(health !== null && isReadyForRemoteSync(health));
       } finally {
         requestInFlight = false;
+        scheduleNextCheck();
       }
     };
 
     void checkReadiness();
-    const intervalId = window.setInterval(
-      () => void checkReadiness(),
-      READY_HEALTH_POLL_INTERVAL_MS
-    );
     const checkOnOnline = () => void checkReadiness();
     window.addEventListener('online', checkOnOnline);
 
     return () => {
       disposed = true;
-      window.clearInterval(intervalId);
+      clearScheduledCheck();
       window.removeEventListener('online', checkOnOnline);
     };
   }, [queryClient]);

--- a/src/entities/purpose/model/usePurposeList.ts
+++ b/src/entities/purpose/model/usePurposeList.ts
@@ -2,11 +2,16 @@ import { useQuery } from '@tanstack/react-query';
 import { purposeList } from '../api/purpose.api';
 import { PurposeResponse } from './types';
 import { AxiosError } from 'axios';
+import { useIsRemoteSyncReady } from '@shared/lib';
 
 export const usePurposeList = () => {
+  const isRemoteSyncReady = useIsRemoteSyncReady();
+
   return useQuery<PurposeResponse[], AxiosError<{ message?: string }>>({
     queryKey: ['purposeList'],
     queryFn: purposeList,
+    enabled: isRemoteSyncReady,
+    retry: false,
     staleTime: 1000 * 60 * 5,
   });
 };

--- a/src/entities/residence/model/useResidenceList.ts
+++ b/src/entities/residence/model/useResidenceList.ts
@@ -2,13 +2,17 @@ import { useQuery } from '@tanstack/react-query';
 import { publicResidenceList, residenceList } from '../index';
 import { useResidenceStore } from './residenceStore';
 import { useEffect } from 'react';
+import { useIsRemoteSyncReady } from '@shared/lib';
 
 export const useResidenceList = () => {
   const setResidences = useResidenceStore((state) => state.setResidences);
+  const isRemoteSyncReady = useIsRemoteSyncReady();
 
   const query = useQuery({
     queryKey: ['residenceList'],
     queryFn: residenceList,
+    enabled: isRemoteSyncReady,
+    retry: false,
   });
 
   useEffect(() => {
@@ -21,9 +25,13 @@ export const useResidenceList = () => {
 };
 
 export const usePublicResidenceList = () => {
+  const isRemoteSyncReady = useIsRemoteSyncReady();
+
   return useQuery({
     queryKey: ['publicResidenceList'],
     queryFn: publicResidenceList,
+    enabled: isRemoteSyncReady,
+    retry: false,
     staleTime: 1000 * 60 * 5,
   });
 };

--- a/src/entities/visit/api/readyHealth.api.ts
+++ b/src/entities/visit/api/readyHealth.api.ts
@@ -29,7 +29,16 @@ const parseReadyHealthResponse = (value: unknown): ReadyHealthResponse => {
 
 export const fetchReadyHealth = async (): Promise<ReadyHealthResponse> => {
   const response = await publicAxiosInstance.get<unknown>(
-    '/common/health/ready'
+    '/common/health/ready',
+    {
+      headers: {
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+      },
+      params: {
+        checkedAt: Date.now(),
+      },
+    }
   );
 
   return parseReadyHealthResponse(response.data);

--- a/src/entities/visit/api/readyHealth.api.ts
+++ b/src/entities/visit/api/readyHealth.api.ts
@@ -1,8 +1,13 @@
-import { publicAxiosInstance } from '@shared/api';
+import axios from 'axios';
 import {
   READY_HEALTH_VALUES,
   type ReadyHealthResponse,
 } from '../model/types';
+
+const readyHealthAxiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+  timeout: 10000,
+});
 
 const isRecordObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
@@ -28,17 +33,9 @@ const parseReadyHealthResponse = (value: unknown): ReadyHealthResponse => {
 };
 
 export const fetchReadyHealth = async (): Promise<ReadyHealthResponse> => {
-  const response = await publicAxiosInstance.get<unknown>(
+  const response = await readyHealthAxiosInstance.get<unknown>(
     '/common/health/ready',
-    {
-      headers: {
-        'Cache-Control': 'no-cache',
-        Pragma: 'no-cache',
-      },
-      params: {
-        checkedAt: Date.now(),
-      },
-    }
+    { params: { checkedAt: Date.now() } }
   );
 
   return parseReadyHealthResponse(response.data);

--- a/src/pages/check-in/CheckInLoginFormPage.tsx
+++ b/src/pages/check-in/CheckInLoginFormPage.tsx
@@ -73,7 +73,9 @@ const CheckInLoginFormPage = () => {
   }, [purposes]);
 
   const visiblePurposes =
-    isPurposeLoading || isPurposeError ? cachedPurposes : purposes;
+    isPurposeLoading || isPurposeError || purposes.length === 0
+      ? cachedPurposes
+      : purposes;
 
   const purposeOptions = useMemo(
     () =>

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,2 +1,3 @@
 export * from './formatters';
 export * from './koreanSearch';
+export * from './remoteSyncAvailability';

--- a/src/shared/lib/remoteSyncAvailability.ts
+++ b/src/shared/lib/remoteSyncAvailability.ts
@@ -1,0 +1,48 @@
+import { useSyncExternalStore } from 'react';
+
+export const REMOTE_SYNC_AVAILABILITY = {
+  UNKNOWN: 'UNKNOWN',
+  READY: 'READY',
+  UNREADY: 'UNREADY',
+} as const;
+
+export type RemoteSyncAvailability =
+  (typeof REMOTE_SYNC_AVAILABILITY)[keyof typeof REMOTE_SYNC_AVAILABILITY];
+
+let currentAvailability: RemoteSyncAvailability =
+  REMOTE_SYNC_AVAILABILITY.UNKNOWN;
+
+const listeners = new Set<() => void>();
+
+const subscribe = (listener: () => void): (() => void) => {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const getRemoteSyncAvailability = (): RemoteSyncAvailability =>
+  currentAvailability;
+
+export const setRemoteSyncAvailability = (
+  availability: RemoteSyncAvailability
+): void => {
+  if (currentAvailability === availability) return;
+
+  currentAvailability = availability;
+  listeners.forEach((listener) => listener());
+};
+
+export const isRemoteSyncReady = (
+  availability: RemoteSyncAvailability
+): boolean => availability === REMOTE_SYNC_AVAILABILITY.READY;
+
+export const useIsRemoteSyncReady = (): boolean =>
+  isRemoteSyncReady(
+    useSyncExternalStore(
+      subscribe,
+      getRemoteSyncAvailability,
+      getRemoteSyncAvailability
+    )
+  );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 원격 동기화 서비스가 준비된 경우에만 방문 목적 및 거주지 목록을 조회합니다.
  - 서비스 상태에 따라 확인 주기를 조정해 복구 상황을 더 빠르게 감지합니다.
  - 동기화 상태 변경 시 관련 데이터가 자동으로 갱신됩니다.

- **버그 수정**
  - 방문 목적 목록을 불러오는 중 오류가 발생하거나 빈 결과가 반환될 때 기존 캐시 데이터를 표시합니다.
  - 준비 상태 확인 요청의 안정성과 최신 상태 반영을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->